### PR TITLE
Fix progress bunny positioning on Safari

### DIFF
--- a/src/components/Progress/ProgressBunnyWrapper.tsx
+++ b/src/components/Progress/ProgressBunnyWrapper.tsx
@@ -3,9 +3,9 @@ import styled from "styled-components";
 const ProgressBunnyWrapper = styled.div`
   display: flex;
   z-index: 2;
-  top: 0;
+  top: -65%;
   position: absolute;
-  transform: translateX(-50%) translateY(-100%);
+  transform: translate(-50%, -50%);
   transition: left 200ms ease-out;
 `;
 


### PR DESCRIPTION
- A 'translate' style that worked well across FF/Chrome etc. pushed the progress bar bunny way up on Safari.
- This modifies the styles to work across both Safari & other browsers.

Now (screenshot from safari):
<img width="940" alt="Screenshot 2020-12-04 at 09 03 58" src="https://user-images.githubusercontent.com/9042672/101144369-213db180-3610-11eb-9b5f-d745d3e4d98d.png">
