### PR TITLE
fix: Add fix for older versions of Safari

### DIFF
--- a/src/hooks/useMatchBreakpoints.ts
+++ b/src/hooks/useMatchBreakpoints.ts
@@ -58,10 +58,16 @@ const useMatchBreakpoints = (): State => {
         }));
       };
 
-      mql.addEventListener("change", handler);
+      // Safari < 14 fix
+      if (mql.addEventListener) {
+        mql.addEventListener("change", handler);
+      }
 
       return () => {
-        mql.removeEventListener("change", handler);
+        // Safari < 14 fix
+        if (mql.removeEventListener) {
+          mql.removeEventListener("change", handler);
+        }
       };
     });
 


### PR DESCRIPTION
Someone pointed out [here](https://github.com/mdn/sprints/issues/858#issuecomment-537992077) that older versions of Safari don't support this (despite docs saying they do).

https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/onchange