### PR TITLE
Fix invalid style within Text component

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -20,7 +20,7 @@ const Text = styled.div<TextProps>`
   font-size: ${getFontSize};
   font-weight: ${({ bold }) => (bold ? 600 : 400)};
   line-height: 1.5;
-  ${({ textTransform }) => textTransform && `text-transform: ${textTransform}`}
+  ${({ textTransform }) => textTransform && `text-transform: ${textTransform};`}
   ${space}
 `;
 


### PR DESCRIPTION
- Add semicolon after `textTransform` to prevent adding a `textTransform` invalidating 'space' styles

[ ] Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-uikit/blob/master/CONTRIBUTING.md) first
[ ] If your PR is work in progress, open it as `draft`
[ ] Before requesting a review, all the checks need to pass
[ ] Explain what your PR does
