### PR TITLE
Table sort fixed

### DIFF
--- a/src/components/Table/hooks.tsx
+++ b/src/components/Table/hooks.tsx
@@ -101,7 +101,7 @@ const createReducer = <T extends DataType>() => (state: TableState<T>, action: T
             ...column,
             sorted: {
               on: true,
-              asc: false,
+              asc: column.sorted.asc,
             },
           };
         }
@@ -319,6 +319,7 @@ export const useTable = <T extends DataType>(
           sort: column.sort,
           sorted: {
             on: false,
+            asc: false,
           },
         };
       }),


### PR DESCRIPTION
There was an issue with table sort functionality which reverts table to the default sorting after user toggles sort.

Fixed by saving the previous column sorting state.